### PR TITLE
Fix Incorrect Keyword Argument in create_order_rest_json Function

### DIFF
--- a/src/aevo.py
+++ b/src/aevo.py
@@ -207,7 +207,7 @@ class AevoClient:
             is_buy,
             limit_price,
             quantity,
-            decimals=1,
+            price_decimals=1,
             post_only=False,
         )
 


### PR DESCRIPTION
## Overview
Fixed an issue where an incorrect keyword argument was used in the `create_order_rest_json` function.

## Changes
- Changed the keyword argument from `decimals` to `price_decimals` in the `create_order_rest_json` function call.

## Impact
This change resolves the TypeError during function invocation, ensuring the function operates as expected.

## Testing
- Confirmed that the error during function call is resolved.
